### PR TITLE
nix-build: extend the meaning of $IN_NIX_SHELL

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -332,7 +332,7 @@ int main(int argc, char ** argv)
         }
 
         if (runEnv)
-            setenv("IN_NIX_SHELL", "1", 1);
+            setenv("IN_NIX_SHELL", pure ? "pure" : "impure", 1);
 
         for (auto & expr : exprs) {
             // Instantiate.


### PR DESCRIPTION
An equivalent was originally filed against the perl version:
https://github.com/NixOS/nix/pull/933
